### PR TITLE
その他の詳細を記入、参照できるようにする

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -66,7 +66,7 @@ class ExpensesController < ApplicationController
   private
 
   def expense_params
-    params.require(:expense).permit(:title, :category, :remark, :paid_at, :paid_to, :amount, :purpose, :comment)
+    params.require(:expense).permit(:title, :category, :category_other_detail, :paid_at, :paid_to, :amount, :purpose, :comment)
   end
 
   def authorized?

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -66,7 +66,7 @@ class ExpensesController < ApplicationController
   private
 
   def expense_params
-    params.require(:expense).permit(:title, :category, :paid_at, :paid_to, :amount, :purpose, :comment)
+    params.require(:expense).permit(:title, :category, :remark, :paid_at, :paid_to, :amount, :purpose, :comment)
   end
 
   def authorized?

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -7,6 +7,8 @@ class Expense < ApplicationRecord
   validates :paid_to, presence: true
   validates :amount, presence: true
   validates :category, presence: true
+  validates :category_other_detail, presence: true,
+    if: Proc.new { |a| a.expenses.category10? }
   validates :approved_at, absence: true,
     if: Proc.new { |a| a.rejected_at.present? }
   validates :rejected_at, absence: true,

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -7,8 +7,8 @@ class Expense < ApplicationRecord
   validates :paid_to, presence: true
   validates :amount, presence: true
   validates :category, presence: true
-  validates :category_other_detail, presence: true,
-    if: Proc.new { |a| a.expenses.category10? }
+  validates :category_other_detail, presence: true, 
+    if: Proc.new { |a| a.category10? }
   validates :approved_at, absence: true,
     if: Proc.new { |a| a.rejected_at.present? }
   validates :rejected_at, absence: true,

--- a/app/views/expenses/_expense.html.haml
+++ b/app/views/expenses/_expense.html.haml
@@ -26,6 +26,8 @@
               %p
                 %span.glyphicon.glyphicon-tags
                 = expense.category_i18n
+                - if expense.category10?
+                  = expense.remark
             %div.col-md-4
               %div.price
                 %span.glyphicon.glyphicon-yen

--- a/app/views/expenses/_expense.html.haml
+++ b/app/views/expenses/_expense.html.haml
@@ -27,7 +27,7 @@
                 %span.glyphicon.glyphicon-tags
                 = expense.category_i18n
                 - if expense.category10?
-                  = expense.remark
+                  = expense.category_other_detail
             %div.col-md-4
               %div.price
                 %span.glyphicon.glyphicon-yen

--- a/app/views/expenses/new.html.haml
+++ b/app/views/expenses/new.html.haml
@@ -11,5 +11,6 @@
         = f.input :paid_to, label: "支払先"
         = f.input :amount, label: "金額"
         = f.input :category, label: "勘定項目"
+        = f.input :remark, label: "その他(詳細)"
       .form-actions
         = f.button :submit, "申請する", class: "btn btn-block btn-primary"

--- a/app/views/expenses/new.html.haml
+++ b/app/views/expenses/new.html.haml
@@ -11,6 +11,6 @@
         = f.input :paid_to, label: "支払先"
         = f.input :amount, label: "金額"
         = f.input :category, label: "勘定項目"
-        = f.input :remark, label: "その他(詳細)"
+        = f.input :category_other_detail, label: "その他(詳細)"
       .form-actions
         = f.button :submit, "申請する", class: "btn btn-block btn-primary"

--- a/config/locales/simple_form.ja.yml
+++ b/config/locales/simple_form.ja.yml
@@ -1,0 +1,4 @@
+ja:
+  simple_form:
+    error_notification:
+      default_message: "エラー😭"

--- a/db/migrate/20180606093437_add_columns_to_expense.rb
+++ b/db/migrate/20180606093437_add_columns_to_expense.rb
@@ -1,0 +1,5 @@
+class AddColumnsToExpense < ActiveRecord::Migration[5.1]
+  def change
+    add_column :expenses, :remark, :text, after: :category
+  end
+end

--- a/db/migrate/20180606093437_add_remark_to_expense.rb
+++ b/db/migrate/20180606093437_add_remark_to_expense.rb
@@ -1,4 +1,4 @@
-class AddColumnsToExpense < ActiveRecord::Migration[5.1]
+class AddRemarkToExpense < ActiveRecord::Migration[5.1]
   def change
     add_column :expenses, :remark, :text, after: :category
   end

--- a/db/migrate/20180608014411_rename_remark_column_to_expenses.rb
+++ b/db/migrate/20180608014411_rename_remark_column_to_expenses.rb
@@ -1,0 +1,5 @@
+class RenameRemarkColumnToExpenses < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :expenses, :remark, :category_other_detail
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111092703) do
+ActiveRecord::Schema.define(version: 20180606093437) do
 
   create_table "companies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20180111092703) do
     t.text "purpose"
     t.bigint "user_id"
     t.integer "category"
+    t.text "remark"
     t.datetime "paid_at"
     t.string "paid_to"
     t.integer "amount"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180606093437) do
+ActiveRecord::Schema.define(version: 20180608014411) do
 
   create_table "companies", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20180606093437) do
     t.text "purpose"
     t.bigint "user_id"
     t.integer "category"
-    t.text "remark"
+    t.text "category_other_detail"
     t.datetime "paid_at"
     t.string "paid_to"
     t.integer "amount"


### PR DESCRIPTION
**やりたいこと**

- その他の詳細を記入するフォームを作成
- 経費詳細画面でカテゴリが「その他」のときだけ詳細も表示

**やったこと**

- remarkカラムを作成
-ストロングパラメーターにremarkを追加
-Viewでカテゴリがその他のときだけ詳細が表示されるように設定

**やらなかったこと**

- validationをつける
　　その他で詳細書かないときもあるかと思いつけなかった。
　　備考欄的にその他を選んでないときでも書き込めるようにしたかった。
**反省**

- 経費の申請なので、その他を明らかにするのは絶対必要。Validation追加すべき。
- その他以外で書き込んだときに参照できるスキームを考えなければならない。

**Before**
[Uploading** Kehi - http___localhost_3456_expenses_new.pdf…]()

**After**

![kehi - http___localhost_3456_expenses_new](https://user-images.githubusercontent.com/38416697/41077042-81be0332-6a4f-11e8-85b5-72ddc61933b9.png)

